### PR TITLE
Embed audio.cpp model specs during SenseVoice GGUF export

### DIFF
--- a/runtime/llama.cpp/README.md
+++ b/runtime/llama.cpp/README.md
@@ -73,6 +73,15 @@ python runtime/llama.cpp/export_sensevoice_gguf.py --wtype f16 \
     --out sensevoice-small-f16.gguf                       # half size
 ```
 
+To make the GGUF directly loadable by audio.cpp's spec-backed runtime, pass a
+`sense_asr` schema-v1 model specification during export:
+```bash
+python runtime/llama.cpp/export_sensevoice_gguf.py --wtype q8_0 \
+    --model_pt <model>/model.pt --mvn <model>/am.mvn \
+    --model-spec model_specs/sense_asr.json \
+    --out sensevoice-small-q8-audiocpp-v1.gguf
+```
+
 **3. Transcribe:**
 ```bash
 build/bin/llama-funasr-sensevoice -m sensevoice-small.gguf -a audio.wav   # prints transcription text

--- a/runtime/llama.cpp/export_sensevoice_gguf.py
+++ b/runtime/llama.cpp/export_sensevoice_gguf.py
@@ -3,7 +3,7 @@
 for the ggml C++ runtime. The encoder is the same SAN-M architecture as
 Fun-ASR-Nano, so the C++ forward is shared.
 """
-import argparse, os, re
+import argparse, json, os, re
 import numpy as np, torch, gguf
 
 
@@ -17,6 +17,16 @@ def parse_mvn(path):
     return shift, scale
 
 
+def load_audio_cpp_model_spec(path):
+    with open(path, encoding="utf-8") as spec_file:
+        model_spec = json.load(spec_file)
+    if model_spec.get("schema_version") != 1:
+        raise ValueError("--model-spec must use schema version 1")
+    if model_spec.get("family") != "sense_asr":
+        raise ValueError("--model-spec family must be sense_asr")
+    return json.dumps(model_spec, ensure_ascii=False, separators=(",", ":"))
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--model_pt", required=True)
@@ -24,8 +34,14 @@ def main():
     ap.add_argument("--out", required=True)
     ap.add_argument("--wtype", default="f32", choices=["f32", "f16", "q8_0"])
     ap.add_argument("--spm", default=None, help="sentencepiece .bpe.model; default: next to model_pt")
+    ap.add_argument(
+        "--model-spec",
+        default=None,
+        help="optional audio.cpp schema-v1 model spec JSON to embed",
+    )
     args = ap.parse_args()
 
+    model_spec_json = load_audio_cpp_model_spec(args.model_spec) if args.model_spec else None
     sd = torch.load(args.model_pt, map_location="cpu"); sd = sd.get("state_dict", sd)
     w = gguf.GGUFWriter(args.out, "sensevoice-small")
     w.add_uint32("sv.input_size", 560)
@@ -36,6 +52,11 @@ def main():
     w.add_uint32("sv.kernel_size", 11)
     w.add_uint32("sv.vocab_size", 25055)
     w.add_uint32("sv.blank_id", 0)
+    if model_spec_json:
+        w.add_uint32("audiocpp.model_spec.version", 1)
+        w.add_string("audiocpp.model_spec.family", "sense_asr")
+        w.add_string("audiocpp.model_spec.json", model_spec_json)
+        print(f"embedded audio.cpp model spec from {args.model_spec}")
     # query token embed indices used at inference: [lid(auto=0), 1, 2, textnorm(woitn=15)]
     w.add_array("sv.query_tokens", [0, 1, 2, 14])  # 14=withitn (use_itn=True), matches authoritative
     import glob

--- a/runtime/llama.cpp/test_export_sensevoice_gguf.py
+++ b/runtime/llama.cpp/test_export_sensevoice_gguf.py
@@ -1,0 +1,43 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import export_sensevoice_gguf
+
+
+class AudioCppModelSpecTest(unittest.TestCase):
+    def write_spec(self, spec):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        path = Path(temp_dir.name) / "model-spec.json"
+        path.write_text(json.dumps(spec), encoding="utf-8")
+        return path
+
+    def test_loads_schema_v1_sense_asr_spec_as_compact_json(self):
+        path = self.write_spec(
+            {"family": "sense_asr", "schema_version": 1, "name": "SenseVoice"}
+        )
+
+        spec_json = export_sensevoice_gguf.load_audio_cpp_model_spec(path)
+
+        self.assertEqual(
+            spec_json,
+            '{"family":"sense_asr","schema_version":1,"name":"SenseVoice"}',
+        )
+
+    def test_rejects_non_sense_asr_family(self):
+        path = self.write_spec({"family": "other", "schema_version": 1})
+
+        with self.assertRaisesRegex(ValueError, "family must be sense_asr"):
+            export_sensevoice_gguf.load_audio_cpp_model_spec(path)
+
+    def test_rejects_non_v1_schema(self):
+        path = self.write_spec({"family": "sense_asr", "schema_version": 2})
+
+        with self.assertRaisesRegex(ValueError, "schema version 1"):
+            export_sensevoice_gguf.load_audio_cpp_model_spec(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an optional `--model-spec` argument to the official SenseVoice GGUF exporter
- validate `sense_asr` schema-v1 specs before loading the checkpoint
- embed the three audio.cpp model-spec metadata keys without changing the default export path
- document Q8_0 audio.cpp export and add focused unit coverage

## Validation
- `python -m unittest -v test_export_sensevoice_gguf.py` (3/3)
- `python -m py_compile export_sensevoice_gguf.py test_export_sensevoice_gguf.py`
- exported 919-tensor Q8_0 GGUF from SenseVoiceSmall revision `3847d57b6bdf2dd8875cb1508d2af43d80a16bf7`
- direct audio.cpp CPU inference without `--model-spec-override`: `开饭时间早上9点至下午5点。`
- published artifact: https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF-audiocpp/blob/main/sensevoice-small-q8-audiocpp-v1.gguf

Related downstream integration: https://github.com/0xShug0/audio.cpp/pull/218