### PR TITLE
docs: restore broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,10 +474,10 @@ You can also scan the following DingTalk group QR code to join the community gro
 |:--------------------------------------------------------:|
 | <img src="image/dingding_funasr.png" width="250"/></div> |
 
-<a href="https://star-history.dera.page/#QwenAudio/SenseVoice&modelscope/FunASR&FunAudioLLM/Fun-ASR&Date">
+<a href="https://star-history.dera.page/#QwenAudio/SenseVoice&modelscope/FunASR&QwenAudio/Fun-ASR&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=QwenAudio/SenseVoice,modelscope/FunASR,FunAudioLLM/Fun-ASR&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=QwenAudio/SenseVoice,modelscope/FunASR,FunAudioLLM/Fun-ASR&type=Date" />
-    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=QwenAudio/SenseVoice,modelscope/FunASR,FunAudioLLM/Fun-ASR&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=QwenAudio/SenseVoice,modelscope/FunASR,QwenAudio/Fun-ASR&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=QwenAudio/SenseVoice,modelscope/FunASR,QwenAudio/Fun-ASR&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=QwenAudio/SenseVoice,modelscope/FunASR,QwenAudio/Fun-ASR&type=Date" />
   </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -474,10 +474,10 @@ You can also scan the following DingTalk group QR code to join the community gro
 |:--------------------------------------------------------:|
 | <img src="image/dingding_funasr.png" width="250"/></div> |
 
-<a href="https://www.star-history.com/QwenAudio/SenseVoice">
+<a href="https://star-history.dera.page/#QwenAudio/SenseVoice&modelscope/FunASR&FunAudioLLM/Fun-ASR&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/badge?repo=QwenAudio/SenseVoice&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/badge?repo=QwenAudio/SenseVoice" />
-    <img alt="Star History Rank" src="https://api.star-history.com/badge?repo=QwenAudio/SenseVoice" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=QwenAudio/SenseVoice,modelscope/FunASR,FunAudioLLM/Fun-ASR&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=QwenAudio/SenseVoice,modelscope/FunASR,FunAudioLLM/Fun-ASR&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=QwenAudio/SenseVoice,modelscope/FunASR,FunAudioLLM/Fun-ASR&type=Date" />
   </picture>
 </a>


### PR DESCRIPTION
The Star History chart on the README has been broken for a while due to upstream API restrictions. This PR brings it back so visitors can see the project's growth over time.

Closes the gap left by #314, which had to replace the chart with a static badge.