### PR TITLE
docs(container): stop advertising private GHCR pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,24 +303,15 @@ pip3 install -e ./
 
 SenseVoice can be built and run using Docker to simplify setup, ensure reproducibility, and support both CPU and GPU inference.
 
-### Official image
-
-The official `linux/amd64` runtime image is published to GitHub Container Registry. Model weights are not embedded in the image; they are downloaded into the mounted `/models` cache on first start.
-
-```bash
-docker pull ghcr.io/qwenaudio/sensevoice:latest
-docker run --rm --gpus all \
-  -p 50000:50000 \
-  -v sensevoice-models:/models \
-  ghcr.io/qwenaudio/sensevoice:latest
-```
-
-Open `http://127.0.0.1:50000/docs` after the container becomes healthy. Release tags and immutable `sha-<commit>` tags are available in the [container package](https://github.com/QwenAudio/SenseVoice/pkgs/container/sensevoice).
-
 ### Build with Docker
 ```bash
 docker build -t sensevoice .
 ```
+
+> The build workflow also publishes `ghcr.io/qwenaudio/sensevoice`, but the
+> package is currently private and anonymous pulls return HTTP 401. Use the
+> local build above until the [container package](https://github.com/QwenAudio/SenseVoice/pkgs/container/sensevoice)
+> is marked Public.
 
 ### Run (GPU – default)
 ```bash
@@ -328,7 +319,7 @@ docker run --gpus all -p 50000:50000 sensevoice
 ```
 ### Run (CPU-only)
 ```bash
-docker run --rm -e SENSEVOICE_DEVICE=cpu -p 50000:50000 -v sensevoice-models:/models ghcr.io/qwenaudio/sensevoice:latest
+docker run --rm -e SENSEVOICE_DEVICE=cpu -p 50000:50000 -v sensevoice-models:/models sensevoice
 ```
 ### Docker Compose
 Docker Compose provides an easier way to run SenseVoice with persistent model caching, networking etc. 

--- a/README_zh.md
+++ b/README_zh.md
@@ -274,19 +274,29 @@ export SENSEVOICE_DEVICE=cuda:0
 fastapi run --port 50000
 ```
 
-### Docker 官方镜像
-
-官方 `linux/amd64` 运行时镜像发布在 GitHub Container Registry。镜像不内置模型权重；首次启动会把权重下载到挂载的 `/models` 缓存。
+### 使用 Docker 构建
 
 ```bash
-docker pull ghcr.io/qwenaudio/sensevoice:latest
-docker run --rm --gpus all \
-  -p 50000:50000 \
-  -v sensevoice-models:/models \
-  ghcr.io/qwenaudio/sensevoice:latest
+docker build -t sensevoice .
 ```
 
-容器健康后访问 `http://127.0.0.1:50000/docs`。版本 tag 和不可变的 `sha-<commit>` tag 见 [容器包页面](https://github.com/QwenAudio/SenseVoice/pkgs/container/sensevoice)。CPU 模式增加 `-e SENSEVOICE_DEVICE=cpu` 并移除 `--gpus all`。
+> 构建工作流也会发布 `ghcr.io/qwenaudio/sensevoice`，但该容器包当前为
+> private，匿名拉取会返回 HTTP 401。在[容器包页面](https://github.com/QwenAudio/SenseVoice/pkgs/container/sensevoice)
+> 显示 Public 之前，请使用上面的本地构建。
+
+### 运行（GPU，默认）
+
+```bash
+docker run --rm --gpus all -p 50000:50000 -v sensevoice-models:/models sensevoice
+```
+
+### 运行（仅 CPU）
+
+```bash
+docker run --rm -e SENSEVOICE_DEVICE=cpu -p 50000:50000 -v sensevoice-models:/models sensevoice
+```
+
+容器健康后访问 `http://127.0.0.1:50000/docs`。
 
 ## 微调
 

--- a/tests/test_container_contract.py
+++ b/tests/test_container_contract.py
@@ -39,15 +39,24 @@ class ContainerContractTest(unittest.TestCase):
             workflow,
         )
 
-    def test_readme_uses_public_ghcr_image_and_real_service_port(self):
+    def test_readme_uses_real_service_port_and_no_retired_registry(self):
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
-        self.assertIn("ghcr.io/qwenaudio/sensevoice", readme.lower())
         self.assertIn("-p 50000:50000", readme)
         self.assertNotIn(
             "registry.cn-hangzhou.aliyuncs.com/funasr/sensevoice",
             readme,
         )
+
+    def test_readmes_do_not_offer_private_ghcr_image_as_anonymous_pull(self):
+        for name in ("README.md", "README_zh.md"):
+            readme = (ROOT / name).read_text(encoding="utf-8").lower()
+
+            self.assertNotIn(
+                "docker pull ghcr.io/qwenaudio/sensevoice:latest",
+                readme,
+            )
+            self.assertIn("docker build -t sensevoice .", readme)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- stop advertising the new GHCR package as anonymously pullable while its visibility is private
- keep local Docker builds as the verified public installation path in both English and Chinese READMEs
- add a bilingual regression test that rejects the inaccessible anonymous pull command

Refs #339

## User impact

Users no longer follow an official docker pull command that currently returns HTTP 401. GPU and CPU examples both run the locally built sensevoice image on the actual port 50000.

## Model, API, and runtime impact

- [x] No model behavior changes.
- [ ] Affects SenseVoiceSmall ASR output.
- [ ] Affects emotion, audio-event, or language-tag behavior.
- [x] Affects FastAPI, web UI, ONNX, Docker, or examples.
- [ ] Affects GGUF / llama.cpp runtime assets or docs.
- [ ] Affects Hugging Face, ModelScope, or model-card routing.

## Validation

- [x] I ran the relevant tests or commands: python -m unittest discover -s tests (5 passed)
- [x] I checked changed README/docs/model links.
- [x] I verified affected runtime behavior: the package API reports visibility=private and an anonymous GHCR manifest request returns HTTP 401.

## Screenshots, logs, or transcripts

The regression test failed before the README change because both READMEs contained docker pull ghcr.io/qwenaudio/sensevoice:latest, then passed after the inaccessible command was removed.

## Notes for reviewers

Exact signed+DCO head: a82a144f6de5d4dd751ab3550794fad05068b479. The build workflow and image remain unchanged. Once the package is actually Public and anonymous manifest validation passes, the pull instructions can be restored in a follow-up.