### PR TITLE
Add bounded no-VAD inference for long audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ SenseVoiceSmall examples and the composed FunASR diarization path require `funas
 
 ## Inference
 
-Supports input of audio in any format and of any duration.
+Supports common audio formats. Long recordings must be segmented before they are
+sent to the encoder; the example below uses FSMN-VAD for that segmentation.
 
 ```python
 from funasr import AutoModel
@@ -155,6 +156,29 @@ print(text)
 - `merge_vad`: Whether to merge short audio fragments segmented by the VAD model, with the merged length being `merge_length_s`, in seconds (s).
 - `ban_emo_unk`: Whether to ban the output of the `emo_unk` token.
 </details>
+
+### Long audio without VAD
+
+Passing an hour-long waveform to one `model.generate` call can make encoder
+memory grow far beyond the audio file size. When VAD is not acceptable, use the
+bounded-memory reference script instead. It decodes through ffmpeg, runs
+SenseVoice on fixed 30-second windows with 2 seconds of overlap, and does not
+configure a VAD model:
+
+```bash
+python long_audio_no_vad.py meeting.mp3 \
+  --output meeting.txt \
+  --window-seconds 30 \
+  --overlap-seconds 2
+```
+
+The merged transcript removes only exact text repeated across adjacent window
+boundaries. `meeting.chunks.jsonl` retains every raw model response and window
+offset, so nonmatching output is never silently discarded; pass `--no-dedupe`
+to disable even exact-overlap removal. Window offsets describe input boundaries,
+not word timestamps. This path avoids whole-recording encoder OOM, but fixed
+boundaries can still change recognition around a cut. The VAD pipeline above
+remains the recommended default when content-based segmentation is acceptable.
 
 ### Speaker Diarization
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -115,7 +115,7 @@ SenseVoiceSmall 示例与 FunASR 组合说话人分离路径需要 `funasr>=1.3.
 
 ### 使用 funasr 推理
 
-支持任意格式音频输入，支持任意时长输入
+支持常见格式音频输入。长录音必须先分段再送入编码器；下例使用 FSMN-VAD 完成分段。
 
 ```python
 from funasr import AutoModel
@@ -161,6 +161,25 @@ print(text)
 - `ban_emo_unk`：禁用 emo_unk 标签，禁用后所有的句子都会被赋与情感标签。默认 `False`
 
 </details>
+
+### 不使用 VAD 的长音频推理
+
+把一小时波形直接传给一次 `model.generate` 会使编码器内存远大于音频文件本身。
+当业务不能接受 VAD 时，可使用有界内存参考脚本。它通过 ffmpeg 解码，以默认 30 秒
+窗口和 2 秒重叠调用 SenseVoice，并且不会配置 VAD 模型：
+
+```bash
+python long_audio_no_vad.py meeting.mp3 \
+  --output meeting.txt \
+  --window-seconds 30 \
+  --overlap-seconds 2
+```
+
+合并文本只删除相邻窗口边界处完全相同的重复文字。`meeting.chunks.jsonl` 会保留每个
+窗口的原始模型输出和窗口偏移，因此不匹配的内容不会被静默丢弃；传入 `--no-dedupe`
+可连完全匹配的去重也关闭。窗口偏移是输入窗口边界，并非逐词时间戳。此路径避免把
+整段录音送入编码器造成 OOM，但固定切点仍可能影响边界附近的识别；业务允许按内容
+分段时，仍推荐使用上面的 VAD pipeline。
 
 如果输入均为短音频（小于 30s），并且需要批量化推理，为了加快推理效率，可以移除 vad 模型，并设置 `batch_size`
 

--- a/long_audio_no_vad.py
+++ b/long_audio_no_vad.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Transcribe long audio with SenseVoice using bounded, overlapping windows."""
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+import numpy as np
+
+
+def create_sensevoice_model(auto_model_class, *, model_name, device):
+    """Build the integrated SenseVoice model without adding a VAD pipeline."""
+    return auto_model_class(
+        model=model_name,
+        device=device,
+        disable_update=True,
+    )
+
+
+@contextmanager
+def ffmpeg_pcm_stream(input_path):
+    """Yield ffmpeg stdout as mono 16 kHz little-endian int16 PCM."""
+    command = [
+        "ffmpeg",
+        "-nostdin",
+        "-v",
+        "error",
+        "-i",
+        str(input_path),
+        "-f",
+        "s16le",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "pipe:1",
+    ]
+    with tempfile.TemporaryFile() as errors:
+        try:
+            decoder = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=errors)
+        except FileNotFoundError as error:
+            raise RuntimeError("ffmpeg is required but was not found on PATH") from error
+
+        try:
+            yield decoder.stdout
+        except BaseException:
+            decoder.terminate()
+            decoder.wait()
+            raise
+        finally:
+            if decoder.stdout:
+                decoder.stdout.close()
+
+        return_code = decoder.wait()
+        if return_code:
+            errors.seek(0)
+            detail = errors.read().decode("utf-8", errors="replace").strip()
+            raise RuntimeError(f"ffmpeg failed with exit code {return_code}: {detail}")
+
+
+def iter_overlapping_windows(
+    stream,
+    *,
+    sample_rate=16000,
+    window_seconds=30,
+    overlap_seconds=2,
+):
+    """Yield ``(start_sample, pcm)`` from a little-endian int16 stream."""
+    if sample_rate <= 0 or window_seconds <= 0:
+        raise ValueError("sample_rate and window_seconds must be positive")
+    if not 0 < overlap_seconds < window_seconds:
+        raise ValueError("overlap_seconds must be greater than 0 and below window_seconds")
+
+    window_samples = int(sample_rate * window_seconds)
+    overlap_samples = int(sample_rate * overlap_seconds)
+    if overlap_samples <= 0 or overlap_samples >= window_samples:
+        raise ValueError("overlap_seconds produces an invalid sample count")
+
+    stride_samples = window_samples - overlap_samples
+    window_bytes = window_samples * 2
+    stride_bytes = stride_samples * 2
+    buffer = bytearray()
+    start_sample = 0
+    furthest_emitted_sample = 0
+    eof = False
+
+    while True:
+        while len(buffer) < window_bytes and not eof:
+            block = stream.read(window_bytes - len(buffer))
+            if block:
+                buffer.extend(block)
+            else:
+                eof = True
+
+        if len(buffer) % 2:
+            raise RuntimeError("decoder returned an incomplete int16 PCM sample")
+
+        available_samples = min(len(buffer) // 2, window_samples)
+        end_sample = start_sample + available_samples
+        if available_samples == 0 or end_sample <= furthest_emitted_sample:
+            break
+
+        pcm = np.frombuffer(bytes(buffer[: available_samples * 2]), dtype="<i2").copy()
+        yield start_sample, pcm
+        furthest_emitted_sample = end_sample
+
+        if len(buffer) <= stride_bytes:
+            buffer.clear()
+        else:
+            del buffer[:stride_bytes]
+        start_sample += stride_samples
+
+
+def merge_transcripts(texts, *, min_overlap_chars=4, max_overlap_chars=200):
+    """Merge chunks, removing only exact case-insensitive suffix/prefix overlap."""
+    merged = ""
+    for text in texts:
+        current = text.strip()
+        if not current:
+            continue
+        if not merged:
+            merged = current
+            continue
+
+        limit = min(len(merged), len(current), max_overlap_chars)
+        overlap = 0
+        for size in range(limit, min_overlap_chars - 1, -1):
+            if merged[-size:].casefold() == current[:size].casefold():
+                overlap = size
+                break
+
+        remainder = current[overlap:]
+        if not remainder:
+            continue
+        separator = "" if merged[-1:].isspace() or remainder[:1].isspace() else " "
+        merged += separator + remainder
+    return merged
+
+
+def write_outputs_atomically(text_path, jsonl_path, merged_text, chunks):
+    """Publish merged text and lossless chunk records only after both serialize."""
+    text_path = Path(text_path)
+    jsonl_path = Path(jsonl_path)
+    text_path.parent.mkdir(parents=True, exist_ok=True)
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+
+    text_tmp = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=text_path.parent, delete=False
+    )
+    jsonl_tmp = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=jsonl_path.parent, delete=False
+    )
+    try:
+        with text_tmp, jsonl_tmp:
+            text_tmp.write(merged_text + "\n")
+            for chunk in chunks:
+                json.dump(chunk, jsonl_tmp, ensure_ascii=False)
+                jsonl_tmp.write("\n")
+        os.replace(jsonl_tmp.name, jsonl_path)
+        os.replace(text_tmp.name, text_path)
+    finally:
+        for name in (text_tmp.name, jsonl_tmp.name):
+            if os.path.exists(name):
+                os.unlink(name)
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="SenseVoice long-audio inference without VAD"
+    )
+    parser.add_argument("input", type=Path)
+    parser.add_argument("--output", type=Path, default=Path("transcript.txt"))
+    parser.add_argument("--chunks-output", type=Path)
+    parser.add_argument("--model", default="iic/SenseVoiceSmall")
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--language", default="auto")
+    parser.add_argument("--window-seconds", type=float, default=30)
+    parser.add_argument("--overlap-seconds", type=float, default=2)
+    parser.add_argument("--no-dedupe", action="store_true")
+    parser.add_argument("--no-itn", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    from funasr import AutoModel
+    from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+    model = create_sensevoice_model(
+        AutoModel,
+        model_name=args.model,
+        device=args.device,
+    )
+    chunks = []
+    try:
+        with ffmpeg_pcm_stream(args.input) as pcm_stream:
+            for index, (start_sample, pcm_i16) in enumerate(
+                iter_overlapping_windows(
+                    pcm_stream,
+                    window_seconds=args.window_seconds,
+                    overlap_seconds=args.overlap_seconds,
+                )
+            ):
+                pcm = pcm_i16.astype(np.float32) / 32768.0
+                result = model.generate(
+                    input=pcm,
+                    cache={},
+                    language=args.language,
+                    use_itn=not args.no_itn,
+                    batch_size_s=args.window_seconds,
+                )
+                raw_text = result[0]["text"]
+                text = rich_transcription_postprocess(raw_text)
+                chunks.append(
+                    {
+                        "index": index,
+                        "start_ms": round(start_sample * 1000 / 16000),
+                        "end_ms": round((start_sample + len(pcm_i16)) * 1000 / 16000),
+                        "raw_text": raw_text,
+                        "text": text,
+                    }
+                )
+    except RuntimeError as error:
+        raise SystemExit(str(error)) from error
+
+    texts = [chunk["text"] for chunk in chunks]
+    merged = " ".join(texts) if args.no_dedupe else merge_transcripts(texts)
+    chunks_output = args.chunks_output or args.output.with_suffix(".chunks.jsonl")
+    write_outputs_atomically(args.output, chunks_output, merged, chunks)
+    print(f"wrote {args.output} and {chunks_output} ({len(chunks)} windows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_long_audio_no_vad.py
+++ b/tests/test_long_audio_no_vad.py
@@ -1,0 +1,133 @@
+import io
+import json
+import tempfile
+import unittest
+import wave
+from pathlib import Path
+
+import numpy as np
+
+from long_audio_no_vad import (
+    create_sensevoice_model,
+    ffmpeg_pcm_stream,
+    iter_overlapping_windows,
+    merge_transcripts,
+    write_outputs_atomically,
+)
+
+
+class ShortReadStream(io.BytesIO):
+    def read(self, size=-1):
+        if size < 0:
+            return super().read(size)
+        return super().read(min(size, 5))
+
+
+class LongAudioNoVadTest(unittest.TestCase):
+    def test_model_is_created_without_vad_or_remote_code(self):
+        calls = []
+
+        class FakeAutoModel:
+            def __init__(self, **kwargs):
+                calls.append(kwargs)
+
+        create_sensevoice_model(
+            FakeAutoModel,
+            model_name="iic/SenseVoiceSmall",
+            device="cpu",
+        )
+
+        self.assertEqual(
+            calls,
+            [
+                {
+                    "model": "iic/SenseVoiceSmall",
+                    "device": "cpu",
+                    "disable_update": True,
+                }
+            ],
+        )
+
+    def test_windows_cover_input_and_do_not_emit_overlap_only_tail(self):
+        samples = np.arange(11, dtype=np.int16)
+        stream = ShortReadStream(samples.tobytes())
+
+        windows = list(
+            iter_overlapping_windows(
+                stream,
+                sample_rate=1,
+                window_seconds=6,
+                overlap_seconds=2,
+            )
+        )
+
+        self.assertEqual([start for start, _ in windows], [0, 4, 8])
+        self.assertEqual(
+            [window.tolist() for _, window in windows],
+            [[0, 1, 2, 3, 4, 5], [4, 5, 6, 7, 8, 9], [8, 9, 10]],
+        )
+
+    def test_window_validation_rejects_invalid_overlap(self):
+        for overlap in (0, 6, 7):
+            with self.subTest(overlap=overlap):
+                with self.assertRaisesRegex(ValueError, "overlap_seconds"):
+                    list(
+                        iter_overlapping_windows(
+                            io.BytesIO(b""),
+                            sample_rate=1,
+                            window_seconds=6,
+                            overlap_seconds=overlap,
+                        )
+                    )
+
+    def test_merge_only_removes_exact_boundary_overlap(self):
+        self.assertEqual(
+            merge_transcripts(["alpha beta", "beta gamma"], min_overlap_chars=4),
+            "alpha beta gamma",
+        )
+        self.assertEqual(
+            merge_transcripts(["repeat", "unrelated"], min_overlap_chars=4),
+            "repeat unrelated",
+        )
+
+    def test_atomic_outputs_keep_raw_chunks_when_merged_text_deduplicates(self):
+        chunks = [
+            {"index": 0, "start_ms": 0, "end_ms": 6000, "raw_text": "alpha beta"},
+            {"index": 1, "start_ms": 4000, "end_ms": 10000, "raw_text": "beta gamma"},
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            text_path = Path(tmp) / "result.txt"
+            jsonl_path = Path(tmp) / "result.chunks.jsonl"
+            write_outputs_atomically(
+                text_path,
+                jsonl_path,
+                "alpha beta gamma",
+                chunks,
+            )
+
+            self.assertEqual(text_path.read_text(encoding="utf-8"), "alpha beta gamma\n")
+            records = [
+                json.loads(line)
+                for line in jsonl_path.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(records, chunks)
+
+    def test_ffmpeg_stream_decodes_container_audio_to_mono_16khz_pcm(self):
+        samples = np.array([0, 1000, -1000, 2000], dtype=np.int16)
+        with tempfile.TemporaryDirectory() as tmp:
+            wav_path = Path(tmp) / "input.wav"
+            with wave.open(str(wav_path), "wb") as wav_file:
+                wav_file.setnchannels(1)
+                wav_file.setsampwidth(2)
+                wav_file.setframerate(16000)
+                wav_file.writeframes(samples.tobytes())
+
+            with ffmpeg_pcm_stream(wav_path) as stream:
+                decoded = np.frombuffer(stream.read(), dtype="<i2")
+
+            np.testing.assert_array_equal(decoded, samples)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an ffmpeg-backed, bounded-memory long-audio reference path without a VAD model
- use fixed overlapping windows and remove only exact repeated boundary text
- preserve every raw window response and input-window offset in JSONL
- correct the README claim that an entire recording of arbitrary duration can be sent to one encoder call

## Why

Users in #7 reported that passing a whole long recording to one `model.generate` call can request tens or hundreds of GiB. This gives users who cannot use VAD an explicit bounded alternative without claiming that fixed windows are lossless at their boundaries.

This PR is **related to #7** and intentionally does not close it. The issue should remain open until the reporters confirm the path on their long recordings or equivalent reproducible evidence is available after a reasonable feedback window.

## Validation

Exact head: `b8d141b2fb7bfe78a90316615f5662bae627d2fd`

- `python -m unittest discover -s tests -v`: 11 passed
- `python -m py_compile long_audio_no_vad.py tests/test_long_audio_no_vad.py`
- `git diff --check`
- real SenseVoiceSmall inference on the repository 6-second WAV, CPU, FunASR 1.3.14 / PyTorch 2.12.1: one window, `0-6000 ms`, non-empty TXT and raw JSONL
- forced overlap inference on the same WAV: two windows, `0-4000 ms` and `3000-6000 ms`, both raw responses retained

Signed-off-by: LauraGPT <18321252+LauraGPT@users.noreply.github.com>