### PR TITLE
fix(container): start on CPU when device=auto and align run commands

### DIFF
--- a/.github/workflows/sensevoice-container.yml
+++ b/.github/workflows/sensevoice-container.yml
@@ -4,11 +4,18 @@ on:
   pull_request:
     paths:
       - Dockerfile
+      - docker-compose.yaml
       - requirements.txt
       - api.py
       - model.py
+      - utils/device_env.py
+      - README.md
+      - README_zh.md
+      - README_ja.md
+      - CONTRIBUTING.md
       - .github/workflows/sensevoice-container.yml
       - tests/test_container_contract.py
+      - tests/test_device_env.py
   push:
     branches:
       - main
@@ -16,11 +23,18 @@ on:
       - "v*"
     paths:
       - Dockerfile
+      - docker-compose.yaml
       - requirements.txt
       - api.py
       - model.py
+      - utils/device_env.py
+      - README.md
+      - README_zh.md
+      - README_ja.md
+      - CONTRIBUTING.md
       - .github/workflows/sensevoice-container.yml
       - tests/test_container_contract.py
+      - tests/test_device_env.py
   workflow_dispatch:
 
 permissions:
@@ -37,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate container contract
-        run: python -m unittest tests.test_container_contract
+        run: python -m unittest tests.test_container_contract tests.test_device_env
 
   build:
     needs: contract

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,11 +145,13 @@ You can also run SenseVoice using Docker:
 docker build -t sensevoice .
 
 # Run with GPU
-docker run --gpus all -p 50000:50000 sensevoice
+docker run --rm --gpus all -p 50000:50000 -v sensevoice-models:/models sensevoice
 
 # Run on CPU
-docker run -e SENSEVOICE_DEVICE=cpu -p 50000:50000 sensevoice
+docker run --rm -e SENSEVOICE_DEVICE=cpu -p 50000:50000 -v sensevoice-models:/models sensevoice
 ```
+
+Do not advertise `docker pull` for `ghcr.io/qwenaudio/sensevoice` or the old Aliyun registry while those paths return HTTP 401 for anonymous clients. Port is 50000, not 60001.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -339,18 +339,22 @@ docker build -t sensevoice .
 
 ### Run (GPU – default)
 ```bash
-docker run --gpus all -p 50000:50000 sensevoice
+docker run --rm --gpus all -p 50000:50000 -v sensevoice-models:/models sensevoice
 ```
 ### Run (CPU-only)
 ```bash
 docker run --rm -e SENSEVOICE_DEVICE=cpu -p 50000:50000 -v sensevoice-models:/models sensevoice
 ```
+
+The container listens on port 50000. After it is healthy, open `http://127.0.0.1:50000/docs`.
+
 ### Docker Compose
-Docker Compose provides an easier way to run SenseVoice with persistent model caching, networking etc. 
+Docker Compose builds the same image and keeps the model cache on the `sensevoice-models` volume. The default compose file does not request GPUs, so it starts on CPU hosts. For GPU, use the `docker run --gpus all` command above.
 
 ### Start Stack
 ```bash
 docker compose up --build
+# CPU is the default. Equivalent: SENSEVOICE_DEVICE=cpu docker compose up --build
 ```
 ### Data prepare
 

--- a/api.py
+++ b/api.py
@@ -1,7 +1,7 @@
 # Set the device with environment, default is cuda:0
 # export SENSEVOICE_DEVICE=cuda:1
 
-import os, re
+import re
 from fastapi import FastAPI, File, Form, UploadFile
 from fastapi.responses import HTMLResponse
 from typing_extensions import Annotated
@@ -11,6 +11,7 @@ import torchaudio
 from model import SenseVoiceSmall
 from funasr.utils.postprocess_utils import rich_transcription_postprocess
 from io import BytesIO
+from utils.device_env import resolve_sensevoice_device
 
 TARGET_FS = 16000
 
@@ -26,7 +27,9 @@ class Language(str, Enum):
 
 
 model_dir = "iic/SenseVoiceSmall"
-m, kwargs = SenseVoiceSmall.from_pretrained(model=model_dir, device=os.getenv("SENSEVOICE_DEVICE", "cuda:0"))
+m, kwargs = SenseVoiceSmall.from_pretrained(
+    model=model_dir, device=resolve_sensevoice_device()
+)
 m.eval()
 
 regex = r"<\|.*\|>"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,9 @@ services:
       options:
         max-size: "5m"
         max-file: "3"
-    gpus: all
+    # No GPU reservation. A default one makes `docker compose up` fail on
+    # hosts without the NVIDIA runtime, which is the CPU path from issue 339.
+    # GPU users should use `docker run --gpus all`.
 
 volumes:
   sensevoice-models:

--- a/tests/test_container_contract.py
+++ b/tests/test_container_contract.py
@@ -43,9 +43,41 @@ class ContainerContractTest(unittest.TestCase):
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
         self.assertIn("-p 50000:50000", readme)
+        self.assertNotIn("60001", readme)
         self.assertNotIn(
             "registry.cn-hangzhou.aliyuncs.com/funasr/sensevoice",
             readme,
+        )
+
+    def test_verified_docker_run_is_identical_across_docs(self):
+        gpu = (
+            "docker run --rm --gpus all -p 50000:50000 "
+            "-v sensevoice-models:/models sensevoice"
+        )
+        cpu = (
+            "docker run --rm -e SENSEVOICE_DEVICE=cpu -p 50000:50000 "
+            "-v sensevoice-models:/models sensevoice"
+        )
+        for name in ("README.md", "README_zh.md", "README_ja.md", "CONTRIBUTING.md"):
+            text = (ROOT / name).read_text(encoding="utf-8")
+            self.assertIn(gpu, text, msg=name)
+            if name != "README_ja.md":
+                self.assertIn(cpu, text, msg=name)
+
+    def test_default_compose_starts_without_a_gpu_reservation(self):
+        compose = (ROOT / "docker-compose.yaml").read_text(encoding="utf-8")
+
+        self.assertIn("50000:50000", compose)
+        self.assertIn("sensevoice-models:/models", compose)
+        self.assertNotIn("gpus:", compose)
+
+    def test_api_uses_resolved_device_not_raw_auto(self):
+        api = (ROOT / "api.py").read_text(encoding="utf-8")
+
+        self.assertIn("resolve_sensevoice_device()", api)
+        self.assertNotIn(
+            'SenseVoiceSmall.from_pretrained(model=model_dir, device=os.getenv("SENSEVOICE_DEVICE", "cuda:0"))',
+            api,
         )
 
     def test_readmes_do_not_offer_private_ghcr_image_as_anonymous_pull(self):

--- a/tests/test_device_env.py
+++ b/tests/test_device_env.py
@@ -1,0 +1,27 @@
+import unittest
+
+from utils.device_env import resolve_sensevoice_device
+
+
+class ResolveSensevoiceDeviceTest(unittest.TestCase):
+    def test_explicit_cpu(self):
+        self.assertEqual(resolve_sensevoice_device("cpu", cuda_available=True), "cpu")
+
+    def test_explicit_cuda(self):
+        self.assertEqual(
+            resolve_sensevoice_device("cuda:1", cuda_available=False), "cuda:1"
+        )
+
+    def test_auto_prefers_cuda_when_present(self):
+        self.assertEqual(
+            resolve_sensevoice_device("auto", cuda_available=True), "cuda:0"
+        )
+
+    def test_auto_falls_back_to_cpu(self):
+        self.assertEqual(
+            resolve_sensevoice_device("auto", cuda_available=False), "cpu"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/device_env.py
+++ b/utils/device_env.py
@@ -1,0 +1,19 @@
+import os
+
+
+def resolve_sensevoice_device(requested=None, cuda_available=None):
+    """Map SENSEVOICE_DEVICE to a FunASR device string.
+
+    The image defaults to ``auto``. FunASR/torch want ``cuda:0`` or ``cpu``.
+    Passing ``auto`` through would fail on hosts without a GPU, which is the
+    path the original Docker issue was hitting.
+    """
+    if requested is None:
+        requested = os.getenv("SENSEVOICE_DEVICE", "cuda:0")
+    if requested != "auto":
+        return requested
+    if cuda_available is None:
+        import torch
+
+        cuda_available = torch.cuda.is_available()
+    return "cuda:0" if cuda_available else "cpu"


### PR DESCRIPTION
## Summary

- English GPU `docker run` now matches the command already verified on zh/ja and in #339: `--rm`, port 50000, and the `sensevoice-models` volume.
- Default `docker-compose.yaml` no longer reserves GPUs, so `docker compose up --build` starts on a machine without the NVIDIA runtime.
- `SENSEVOICE_DEVICE=auto` (the image default) resolves to `cuda:0` or `cpu` instead of being passed into FunASR as the string `auto`.
- Contract tests require the same GPU/CPU run lines across README / README_zh / CONTRIBUTING, and reject the retired Aliyun registry, anonymous GHCR pull, and port 60001.

Refs #339

## User impact

The original report could not pull a public image or start the service. Public pulls are still 401 (Aliyun and GHCR). The path that should actually start is the local build. After this change the English start command, compose, and `auto` device match that path, including on CPU hosts.

## Model, API, and runtime impact

- [x] No model behavior changes.
- [ ] Affects SenseVoiceSmall ASR output.
- [ ] Affects emotion, audio-event, or language-tag behavior.
- [x] Affects FastAPI, web UI, ONNX, Docker, or examples.
- [ ] Affects GGUF / llama.cpp runtime assets or docs.
- [ ] Affects Hugging Face, ModelScope, or model-card routing.

## Validation

- [x] I ran the relevant tests or commands: `python -m unittest tests.test_container_contract tests.test_device_env` (12 passed)
- [x] I checked changed README/docs/model links.
- [x] I verified affected runtime behavior from a clean amd64 host (Docker 28.2.2):

```
# anonymous GHCR
curl -sI https://ghcr.io/v2/qwenaudio/sensevoice/manifests/latest
HTTP/2 401

# anonymous Aliyun
curl -sI https://registry.cn-hangzhou.aliyuncs.com/v2/funasr/sensevoice/manifests/latest
HTTP/2 401
```

Dockerfile still `EXPOSE 50000`. I did not rebuild the full pytorch image locally; the container workflow on this PR will do that.

## Screenshots, logs, or transcripts

Before, English GPU run was `docker run --gpus all -p 50000:50000 sensevoice` (no volume, no `--rm`). After, it is the same line as zh/ja:

```
docker run --rm --gpus all -p 50000:50000 -v sensevoice-models:/models sensevoice
```

`resolve_sensevoice_device("auto", cuda_available=False)` returns `cpu`.

## Notes for reviewers

Issue stays open until the reporter confirms the local build. GHCR visibility is still private; this PR does not advertise an anonymous pull.

Made with [Cursor](https://cursor.com)