### PR TITLE
build: exclude local credentials from SenseVoice image context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Repository metadata and local credentials are not runtime inputs.
+.git
+**/.git
+.env
+**/.env
+.env.*
+**/.env.*
+.ssh
+**/.ssh
+.aws
+**/.aws
+.netrc
+**/.netrc
+.pypirc
+**/.pypirc
+**/github_token
+**/hf_token
+.mcp-tasks
+**/.mcp-tasks
+
+# Local development environments and generated caches.
+.venv
+venv
+**/__pycache__
+.pytest_cache
+.mypy_cache

--- a/.github/workflows/sensevoice-container.yml
+++ b/.github/workflows/sensevoice-container.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - Dockerfile
+      - .dockerignore
       - docker-compose.yaml
       - requirements.txt
       - api.py
@@ -15,6 +16,7 @@ on:
       - CONTRIBUTING.md
       - .github/workflows/sensevoice-container.yml
       - tests/test_container_contract.py
+      - tests/test_docker_context.sh
       - tests/test_device_env.py
   push:
     branches:
@@ -23,6 +25,7 @@ on:
       - "v*"
     paths:
       - Dockerfile
+      - .dockerignore
       - docker-compose.yaml
       - requirements.txt
       - api.py
@@ -34,6 +37,7 @@ on:
       - CONTRIBUTING.md
       - .github/workflows/sensevoice-container.yml
       - tests/test_container_contract.py
+      - tests/test_docker_context.sh
       - tests/test_device_env.py
   workflow_dispatch:
 
@@ -50,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Validate container contract
         run: python -m unittest tests.test_container_contract tests.test_device_env
 
@@ -58,7 +64,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@v3
+
+      - name: Verify Docker build context exclusions
+        run: bash tests/test_docker_context.sh
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/tests/test_container_contract.py
+++ b/tests/test_container_contract.py
@@ -6,6 +6,26 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class ContainerContractTest(unittest.TestCase):
+    def test_build_context_excludes_local_credentials_and_git_metadata(self):
+        ignore = ROOT / '.dockerignore'
+        self.assertTrue(ignore.is_file(), 'COPY . requires an explicit context boundary')
+        patterns = {line.strip() for line in ignore.read_text().splitlines()
+                    if line.strip() and not line.lstrip().startswith('#')}
+        required = {'.git', '**/.git', '.env', '**/.env', '.env.*', '**/.env.*',
+                    '.ssh', '**/.ssh', '.aws', '**/.aws', '.netrc', '**/.netrc',
+                    '.pypirc', '**/.pypirc', '**/github_token', '**/hf_token',
+                    '.mcp-tasks', '**/.mcp-tasks'}
+        self.assertTrue(required <= patterns, required - patterns)
+        self.assertFalse(any(pattern.startswith('!') for pattern in patterns))
+
+    def test_context_changes_run_ci_without_persisting_checkout_credentials(self):
+        workflow = (ROOT / '.github/workflows/sensevoice-container.yml').read_text()
+        self.assertEqual(workflow.count('- .dockerignore'), 2)
+        self.assertEqual(workflow.count('persist-credentials: false'),
+                         workflow.count('uses: actions/checkout@v4'))
+        self.assertEqual(workflow.count('- tests/test_docker_context.sh'), 2)
+        self.assertIn('run: bash tests/test_docker_context.sh', workflow)
+
     def test_container_base_matches_repository_torch_floor(self):
         dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
 

--- a/tests/test_docker_context.sh
+++ b/tests/test_docker_context.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+probe=$(mktemp -d .container-context-probe.XXXXXX)
+output=$(mktemp -d "${TMPDIR:-/tmp}/sensevoice-context.XXXXXX")
+trap 'rm -rf -- "$probe" "$output"' EXIT
+
+# Harmless sentinels exercise Docker's matcher without reading credentials.
+mkdir -p "$probe/.git" "$probe/.ssh" "$probe/.aws"
+touch "$probe/.git/sentinel" "$probe/.ssh/sentinel" "$probe/.aws/sentinel"
+touch "$probe/.env" "$probe/.env.test" "$probe/.netrc" "$probe/.pypirc"
+touch "$probe/github_token" "$probe/hf_token" "$probe/runtime-sentinel.txt"
+
+docker buildx build --file - --output "type=local,dest=$output" . <<'DOCKERFILE'
+FROM scratch
+COPY . /
+DOCKERFILE
+
+test ! -e "$output/.git"
+for excluded in .git .ssh .aws .env .env.test .netrc .pypirc github_token hf_token; do
+    test ! -e "$output/$probe/$excluded"
+done
+for required in api.py model.py requirements.txt utils/device_env.py "$probe/runtime-sentinel.txt"; do
+    test -f "$output/$required"
+done
+printf '%s\n' 'Docker context exclusions and runtime inputs verified.'


### PR DESCRIPTION
## Summary

- Add a Docker build-context boundary for Git metadata and common local credential files before `COPY . /app`.
- Disable persisted checkout credentials in both container jobs and trigger the workflow when the ignore rules or context probe change.
- Exercise Docker/BuildKit's actual context matcher with harmless sentinels and verify that required runtime files remain available before the full image build.

## Verification

- New regression tests first failed on the missing ignore file and workflow protections.
- 14 container/device contract tests pass locally; shell syntax and git diff checks pass.
- Read-only review found no P1/P2 issues.
- Docker is not installed on the authorized development host, so the real BuildKit context probe and full image build must pass on the exact PR head in CI. This is not a local image/inference acceptance claim.

The GHCR package remains private. This change does not make anonymous pulls work, change visibility, invalidate published tags, or claim that an actual secret leak was observed. The ignore rules cover common names, not arbitrary secrets embedded in source files. Existing runtime behavior is unchanged.
